### PR TITLE
CRITICAL BUG FIX

### DIFF
--- a/GOLF/Assets/_Project/Scripts/Dialogue/DialogueManager.cs
+++ b/GOLF/Assets/_Project/Scripts/Dialogue/DialogueManager.cs
@@ -161,6 +161,7 @@ namespace Golf
                 InputManager.Source.Enable();
             }
             DisableDialogue().Forget();
+            GameStateManager.Source.ChangeState(GameState.OnPlay);
         }
 
         private void NextDialogue()

--- a/GOLF/Assets/_Project/Scripts/Dialogue/DialogueTrigger.cs
+++ b/GOLF/Assets/_Project/Scripts/Dialogue/DialogueTrigger.cs
@@ -8,6 +8,7 @@ namespace Golf
 
         private void TriggerDialogue()
         {
+            GameStateManager.Source.ChangeState(GameState.OnDialogue);
             DialogueManager.Source.StartDialogue(_dialogue, null, true);
         }
 

--- a/GOLF/Assets/_Project/Scripts/Game/GameStateManager.cs
+++ b/GOLF/Assets/_Project/Scripts/Game/GameStateManager.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace Golf
 {
@@ -20,6 +21,8 @@ namespace Golf
 
         private void SetPauseState()
         {
+            if (SceneManager.GetActiveScene().name == "MainMenu") return;
+
             switch (CurrentGameState)
             {
                 case GameState.OnPlay:
@@ -27,6 +30,9 @@ namespace Golf
                     break;
                 case GameState.OnPause:
                     ChangeState(GameState.OnPlay);
+                    break;
+                case GameState.OnDialogue:
+                    ChangeState(GameState.OnDialogue); 
                     break;
             }
         }
@@ -44,5 +50,6 @@ namespace Golf
     { 
         OnPlay,
         OnPause,
+        OnDialogue,
     }
 }

--- a/GOLF/Assets/_Project/Scripts/Input/InputManager.cs
+++ b/GOLF/Assets/_Project/Scripts/Input/InputManager.cs
@@ -13,6 +13,8 @@ namespace Golf
         public event Action OnNextButtonPresssed;
         public event Action OnPause;
         public event Action<ControllerType> OnControllerTypeChange;
+        public event Action OnDeleteButtonPressed;
+        public event Action OnCancelButtonPressed;
 
         public bool IsLocking { get; set; } = false;
         public ActionState CurrentActionState => _currentAction.ActionState;
@@ -102,17 +104,27 @@ namespace Golf
 
         private void CheckUIButtonInput()
         {
-            if (Input.GetKeyDown(KeyCode.Z))
+            if (Input.GetKeyDown(KeyCode.Z) || Input.GetKeyDown(KeyCode.JoystickButton0))
             {
                 OnConfirmButtonPressed?.Invoke();
             }
 
-            if (Input.GetKeyDown(KeyCode.Comma))
+            if (Input.GetKeyDown(KeyCode.Backspace) || Input.GetKeyDown(KeyCode.JoystickButton2))
+            {
+                OnDeleteButtonPressed?.Invoke();
+            }
+
+            if (Input.GetKeyDown(KeyCode.Escape) || Input.GetKeyDown(KeyCode.JoystickButton1))
+            {
+                OnCancelButtonPressed?.Invoke();
+            }
+
+            if (Input.GetKeyDown(KeyCode.Comma) || Input.GetKeyDown(KeyCode.JoystickButton4))
             {
                 OnPreviousButtonPresssed?.Invoke();
             }
 
-            if (Input.GetKeyDown(KeyCode.Period))
+            if (Input.GetKeyDown(KeyCode.Period) || Input.GetKeyDown(KeyCode.JoystickButton5))
             {
                 OnNextButtonPresssed?.Invoke();
             }
@@ -136,7 +148,7 @@ namespace Golf
 
         private void PauseButton()
         {
-            if (Input.GetKeyDown(KeyCode.Escape))
+            if ((Input.GetKeyDown(KeyCode.Escape) || Input.GetKeyDown(KeyCode.JoystickButton7)) && GameStateManager.Source.CurrentGameState != GameState.OnDialogue)
             {
                 OnPause?.Invoke();
             }


### PR DESCRIPTION
Critical bug which caused a soft reset during the LevelSelector and Tutorial because of the InputManager and GameStateManager. Fixed bug of pause during dialogues. Added a new game state and set the corresponding conditions.


https://github.com/user-attachments/assets/25f808e6-38b3-4cfc-aec2-07fcd2b86c9a

Close #166 