### PR TITLE
Added functionality to load a game file on any scene

### DIFF
--- a/GOLF/Assets/_Project/Prefabs/Managers/SaveSystem.prefab
+++ b/GOLF/Assets/_Project/Prefabs/Managers/SaveSystem.prefab
@@ -45,3 +45,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _isPersistent: 1
+  _forceLoadGame: 1
+  _forceLoadGameIndex: 0

--- a/GOLF/Assets/_Project/Scenes/MainMenu.unity
+++ b/GOLF/Assets/_Project/Scenes/MainMenu.unity
@@ -2215,6 +2215,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7585941226440248819, guid: 298e8d3bf9ee8ac45aae36849044905d, type: 3}
+      propertyPath: _forceLoadGame
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/GOLF/Assets/_Project/Scripts/Save System/SaveSystem.cs
+++ b/GOLF/Assets/_Project/Scripts/Save System/SaveSystem.cs
@@ -1,7 +1,6 @@
 using System.IO;
 using UnityEngine;
 using Newtonsoft.Json;
-using static UnityEngine.Rendering.DebugUI;
 
 namespace Golf
 {
@@ -15,6 +14,10 @@ namespace Golf
 
         private GameSettingsData _currentSettingsData;
         private GameData _currentGameData;
+        
+        [Header("CONFIGURATIONS")]
+        [SerializeField] private bool _forceLoadGame = false;
+        [SerializeField] private int _forceLoadGameIndex = 0;
 
         protected override void Awake()
         {
@@ -23,6 +26,11 @@ namespace Golf
             if (_hasBeenDestroyed) return;
             
             LoadSettings();
+
+            if (_forceLoadGame)
+            {
+                LoadGame(_forceLoadGameIndex);
+            }
         }
 
         private void OnGameQuit()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7b853afd-71cd-4b77-ac81-428197d1a018)

The force load is activated on all scenes except ´MainMenu´, this way the first file will be loaded correctly before starting the game, adjust this as you see fit but try to not commit changes to these 2 fields, are only meant for testing.

Closes #176 
Closes #177 