### PR TITLE
Cursor disabled

### DIFF
--- a/GOLF/Assets/_Project/Scripts/Input/InputManager.cs
+++ b/GOLF/Assets/_Project/Scripts/Input/InputManager.cs
@@ -63,6 +63,9 @@ namespace Golf
 
         private void Start()
         {
+            Cursor.visible = false;
+            Cursor.lockState = CursorLockMode.Locked;
+
             GameStateManager.Source.OnGameStateChanged += OnGameStatedChanged;
         }
 


### PR DESCRIPTION
The mouse was disabled, and its visibility was also deactivated. In the video, the mouse you see is because I pressed ESC to exit game mode in Unity to indicate which key I want to press.

https://github.com/user-attachments/assets/5515f159-9574-48bc-8f5b-97d878abdf9a

