### PR TITLE
Text's alpha reduced

### DIFF
--- a/GOLF/Assets/_Project/Scenes/FireballCave.unity
+++ b/GOLF/Assets/_Project/Scenes/FireballCave.unity
@@ -1731,6 +1731,14 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1325333295222892001, guid: f8ac41656ca63714c865df855b0adfd6, type: 3}
+      propertyPath: m_fontColor.a
+      value: 0.03137255
+      objectReference: {fileID: 0}
+    - target: {fileID: 1325333295222892001, guid: f8ac41656ca63714c865df855b0adfd6, type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 150994943
+      objectReference: {fileID: 0}
     - target: {fileID: 1524683112173116464, guid: f8ac41656ca63714c865df855b0adfd6, type: 3}
       propertyPath: m_Name
       value: UIManager

--- a/GOLF/Assets/_Project/Scenes/LevelSelector.unity
+++ b/GOLF/Assets/_Project/Scenes/LevelSelector.unity
@@ -7921,6 +7921,14 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1325333295222892001, guid: f8ac41656ca63714c865df855b0adfd6, type: 3}
+      propertyPath: m_fontColor.a
+      value: 0.03137255
+      objectReference: {fileID: 0}
+    - target: {fileID: 1325333295222892001, guid: f8ac41656ca63714c865df855b0adfd6, type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 150994943
+      objectReference: {fileID: 0}
     - target: {fileID: 1524683112173116464, guid: f8ac41656ca63714c865df855b0adfd6, type: 3}
       propertyPath: m_Name
       value: UIManager


### PR DESCRIPTION
The alpha of the text was reduced to 3 so that the player understands that in that specific scene their shots would not be counted, but also to keep in mind how many shots they will have in the next level.
Close #162 

![levelselector](https://github.com/user-attachments/assets/b21024d6-375b-45e3-a1fd-78090944bc3b)
![fireball](https://github.com/user-attachments/assets/54c82c22-2811-4554-b54b-869923861117)