### PR TITLE
Remove hits saving in gameover

### DIFF
--- a/GOLF/Assets/_Project/Scripts/Game/GameManager.cs
+++ b/GOLF/Assets/_Project/Scripts/Game/GameManager.cs
@@ -50,5 +50,10 @@ namespace Golf
         {
             OnBallRespawn?.Invoke();
         }
+
+        public void RestoreHitsGameOver()
+        {
+            _strokesNumber = SaveSystem.Source.GetStrokesNumber();
+        }
     }
 }

--- a/GOLF/Assets/_Project/Scripts/Game/IGameSource.cs
+++ b/GOLF/Assets/_Project/Scripts/Game/IGameSource.cs
@@ -14,5 +14,6 @@ namespace Golf
         void TriggerLoseCondition();
         void ResetHitsLeft();
         void RespawnLastPosition();
+        void RestoreHitsGameOver();
     }
 }

--- a/GOLF/Assets/_Project/Scripts/UI/RetryButton.cs
+++ b/GOLF/Assets/_Project/Scripts/UI/RetryButton.cs
@@ -21,6 +21,7 @@ namespace Golf
 
         private void LoadScene()
         {
+            GameManager.Source.RestoreHitsGameOver();
             UIManager.Source.HidePanels();
             LevelManager.Source.LoadScene(_sceneName);
         }


### PR DESCRIPTION
A method was created so that when the player loses, the shots used are not saved, so when they lose, they return to the scene with the number of shots intact.

Close #163 


https://github.com/user-attachments/assets/f6c7dc8d-62f8-4c8b-ab83-d0292616d870

