### PR TITLE
Ice power up

### DIFF
--- a/GOLF/Assets/_Project/Scenes/PowerUpsTest.unity
+++ b/GOLF/Assets/_Project/Scenes/PowerUpsTest.unity
@@ -257,6 +257,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7585941226440248819, guid: 298e8d3bf9ee8ac45aae36849044905d, type: 3}
+      propertyPath: _forceLoadGame
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -280,6 +284,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _ballSprite: {fileID: 83014367}
+  _groundLayer:
+    serializedVersion: 2
+    m_Bits: 8
 --- !u!1 &419074375
 GameObject:
   m_ObjectHideFlags: 0

--- a/GOLF/Assets/_Project/ScriptableObjects/PowerUps/FirePowerUp.asset
+++ b/GOLF/Assets/_Project/ScriptableObjects/PowerUps/FirePowerUp.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b112847a445174b48b80ba0241c4afc6, type: 3}
   m_Name: FirePowerUp
   m_EditorClassIdentifier: 
+  _powerUpType: 2
   _ballMass: 0.3
   _ballAngularDrag: 40
   _ballSprite: {fileID: -1738607512, guid: 6a96c68875506c440ac6999599ead7d4, type: 3}

--- a/GOLF/Assets/_Project/ScriptableObjects/PowerUps/IcePowerUp.asset
+++ b/GOLF/Assets/_Project/ScriptableObjects/PowerUps/IcePowerUp.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b112847a445174b48b80ba0241c4afc6, type: 3}
   m_Name: IcePowerUp
   m_EditorClassIdentifier: 
+  _powerUpType: 1
   _ballMass: 0.5
   _ballAngularDrag: 50
   _ballSprite: {fileID: 1442839142, guid: 6a96c68875506c440ac6999599ead7d4, type: 3}

--- a/GOLF/Assets/_Project/ScriptableObjects/PowerUps/Normal.asset
+++ b/GOLF/Assets/_Project/ScriptableObjects/PowerUps/Normal.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b112847a445174b48b80ba0241c4afc6, type: 3}
   m_Name: Normal
   m_EditorClassIdentifier: 
+  _powerUpName: Normal
   _ballMass: 0.5
   _ballAngularDrag: 50
   _ballSprite: {fileID: 172532299, guid: f829b16319536f9449e9384de5512c23, type: 3}

--- a/GOLF/Assets/_Project/Scripts/Input/IInputSource.cs
+++ b/GOLF/Assets/_Project/Scripts/Input/IInputSource.cs
@@ -14,6 +14,8 @@ namespace Golf
         event Action OnDeleteButtonPressed;
         event Action OnCancelButtonPressed;
 
+        event Action OnPowerUpActivated;
+
         event Action OnConfirmButtonPressed;
         event Action<ActionState> OnActionChange;
         event Action<Vector2> OnMoveCamera;

--- a/GOLF/Assets/_Project/Scripts/Input/InputManager.cs
+++ b/GOLF/Assets/_Project/Scripts/Input/InputManager.cs
@@ -15,6 +15,7 @@ namespace Golf
         public event Action<ControllerType> OnControllerTypeChange;
         public event Action OnDeleteButtonPressed;
         public event Action OnCancelButtonPressed;
+        public event Action OnPowerUpActivated;
 
         public bool IsLocking { get; set; } = false;
         public ActionState CurrentActionState => _currentAction.ActionState;
@@ -84,6 +85,8 @@ namespace Golf
             if (!_isEnabled) return;
             if (GameStateManager.Source.CurrentGameState != GameState.OnPlay) return;
 
+            ChangePowerUpInput();
+            ActivatePowerUpInput();
             CheckGameButtonInput();
         }
 
@@ -121,7 +124,12 @@ namespace Golf
             {
                 OnCancelButtonPressed?.Invoke();
             }
+        }
 
+        private void ChangePowerUpInput()
+        {
+            if (CurrentActionState is not (ActionState.Direction or ActionState.Force)) return;
+  
             if (Input.GetKeyDown(KeyCode.Comma) || Input.GetKeyDown(KeyCode.JoystickButton4))
             {
                 OnPreviousButtonPresssed?.Invoke();
@@ -130,6 +138,14 @@ namespace Golf
             if (Input.GetKeyDown(KeyCode.Period) || Input.GetKeyDown(KeyCode.JoystickButton5))
             {
                 OnNextButtonPresssed?.Invoke();
+            }
+        }
+
+        private void ActivatePowerUpInput()
+        {
+            if (Input.GetKeyDown(KeyCode.P))
+            {
+                OnPowerUpActivated?.Invoke();
             }
         }
 
@@ -144,7 +160,7 @@ namespace Golf
                 {
                     OnMoveCamera?.Invoke(new Vector2(horizontalInput, verticalInput));
                 }
-            }
+            }    
 
             _currentAction.DoAction();
         }

--- a/GOLF/Assets/_Project/Scripts/Player/Actions/DirectionHandler.cs
+++ b/GOLF/Assets/_Project/Scripts/Player/Actions/DirectionHandler.cs
@@ -28,7 +28,14 @@ namespace Golf
         private void AdjustAngleBasedOnInput(float input)
         {
             _angle -= input * DIRECTION_CHANGE_SPEED * Time.deltaTime;
-            _angle = Mathf.Clamp(_angle, 0f, 180f);
+            float maxAngle = 180f;
+
+            if (PowerUpSystem.Source?.IsEffectActivated == true)
+            {
+                maxAngle = 360f;
+            }
+
+            _angle = Mathf.Clamp(_angle, 0f, maxAngle);
             OnDirectionChange?.Invoke(_angle);
         }
     }

--- a/GOLF/Assets/_Project/Scripts/PowerUps/IPowerSource.cs
+++ b/GOLF/Assets/_Project/Scripts/PowerUps/IPowerSource.cs
@@ -5,6 +5,10 @@ namespace Golf
     public interface IPowerSource
     {
         event Action<PowerUpData> OnPowerUpSelected;
+        PowerUpData CurrentPowerUpData { get; }
         void ApplyPowerUpData(PowerUpData powerUpData);
+        bool IsEffectActivated { get; set; }
+        bool TryActivatePowerUp();
+        void StrokesCooldown();
     }
 }

--- a/GOLF/Assets/_Project/Scripts/PowerUps/PowerUpData.cs
+++ b/GOLF/Assets/_Project/Scripts/PowerUps/PowerUpData.cs
@@ -5,14 +5,26 @@ namespace Golf
     [CreateAssetMenu(fileName = "NewPowerUp", menuName = "PowerUps/Powerup Data")]
     public class PowerUpData : ScriptableObject
     {
+        [SerializeField] private PowerUpType _powerUpType;
         [SerializeField] private float _ballMass;
         [SerializeField] private float _ballAngularDrag;
         [SerializeField] private Sprite _ballSprite;
         [SerializeField] private int _hardness;
+        [SerializeField] private bool _hasEffect;
 
+        public PowerUpType PowerUpType => _powerUpType;
         public float BallMass => _ballMass;
         public float BallAngularDrag => _ballAngularDrag;
         public Sprite BallSprite => _ballSprite;
         public int Hardness => _hardness;
+        public bool HasEffect => _hasEffect;
+    }
+
+    public enum PowerUpType
+    {
+        None,
+        Ice,
+        Fire,
+        Stone,
     }
 }

--- a/GOLF/Assets/_Project/Scripts/PowerUps/PowerUpSystem.cs
+++ b/GOLF/Assets/_Project/Scripts/PowerUps/PowerUpSystem.cs
@@ -5,11 +5,43 @@ namespace Golf
 {
     public class PowerUpSystem : Singleton<IPowerSource>, IPowerSource
     {
+        private const int STROKES_REQUIRED = 3;
+
         public event Action<PowerUpData> OnPowerUpSelected;
+        public PowerUpData CurrentPowerUpData => _currentPowerUp;
+
+        public bool IsEffectActivated { get; set; } = false;
+
+        private PowerUpData _currentPowerUp;
+        private bool _isOnCooldown = false;
+        private int _strikesSinceLastActivated = 0;
 
         public void ApplyPowerUpData(PowerUpData powerUpData)
         {
+            IsEffectActivated = false;
+            _currentPowerUp = powerUpData;
             OnPowerUpSelected?.Invoke(powerUpData);
+        }
+
+        public bool TryActivatePowerUp()
+        {
+            if (_isOnCooldown || _currentPowerUp.HasEffect == false) return false;
+
+            _isOnCooldown = true;
+            _strikesSinceLastActivated = 0;
+            return true;
+        }
+
+        public void StrokesCooldown()
+        {
+            if(!_isOnCooldown) return;
+
+            _strikesSinceLastActivated++;
+            if (_strikesSinceLastActivated >= STROKES_REQUIRED)
+            {
+                _isOnCooldown = false;
+                _strikesSinceLastActivated = 0;
+            }
         }
     }
 }


### PR DESCRIPTION
Created the ice power up following the game design document. It stops mid air whenever it's activated (with the P key) and the player can hit the ball again but now it's possible to set the direction up to 360 deg instead of 180. It also has a cooldown of 2 hits after its activation, no matter if you change power ups and change back to ice, the cooldown is still there.


https://github.com/user-attachments/assets/7f5046e4-9172-4d5c-bfc6-b959fcce77a5

Close #203 