### PR TITLE
Disable ball on game over

### DIFF
--- a/GOLF/Assets/_Project/Scripts/Game/GameStateManager.cs
+++ b/GOLF/Assets/_Project/Scripts/Game/GameStateManager.cs
@@ -34,6 +34,9 @@ namespace Golf
                 case GameState.OnDialogue:
                     ChangeState(GameState.OnDialogue); 
                     break;
+                case GameState.OnGameOver:
+                    ChangeState(GameState.OnGameOver);
+                    break;
             }
         }
 
@@ -51,5 +54,6 @@ namespace Golf
         OnPlay,
         OnPause,
         OnDialogue,
+        OnGameOver
     }
 }

--- a/GOLF/Assets/_Project/Scripts/Player/BallController.cs
+++ b/GOLF/Assets/_Project/Scripts/Player/BallController.cs
@@ -127,7 +127,7 @@ namespace Golf
             _stopTimer = 0f;
             _currentLastPosition = transform.position;
             
-            if (!_isOnPole)
+            if (!_isOnPole && GameManager.Source.CurrentHitsLeft != 0)
             {
                 _inputSource.ChangeAction(ActionState.Direction);
                 _onAirThrows = 1;

--- a/GOLF/Assets/_Project/Scripts/UI/MainMenu/SlotButton.cs
+++ b/GOLF/Assets/_Project/Scripts/UI/MainMenu/SlotButton.cs
@@ -74,6 +74,7 @@ namespace Golf
             {
                 LevelManager.Source.LoadScene(HUB_SCENE);
             }
+            GameStateManager.Source.ChangeState(GameState.OnPlay);
         }
 
         private void DisplaySlotData()

--- a/GOLF/Assets/_Project/Scripts/UI/UIManager.cs
+++ b/GOLF/Assets/_Project/Scripts/UI/UIManager.cs
@@ -45,6 +45,7 @@ namespace Golf
         public void ShowLosePanel()
         {
             _losePanel.SetActive(true);
+            GameStateManager.Source.ChangeState(GameState.OnGameOver);
             EventSystem.current.SetSelectedGameObject(_backToMenuButton.gameObject);
         }
 


### PR DESCRIPTION
Created a new game state called OnGameOver when the Game Over Panel is shown, also set the game state to OnPlay when a slot button is selected to prevent issues from the game not being set to a playable state. Here's a video showing how it works.

https://github.com/user-attachments/assets/20f63f92-ab40-44ab-96d4-94cc676388d6

Close #225 
Close #228 
