### PR TITLE
Reset original hits after file deleted

### DIFF
--- a/GOLF/Assets/_Project/Prefabs/Managers/GameManager.prefab
+++ b/GOLF/Assets/_Project/Prefabs/Managers/GameManager.prefab
@@ -45,4 +45,4 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _isPersistent: 1
-  _strokesNumber: 20
+  _strokesNumber: 50

--- a/GOLF/Assets/_Project/Scripts/Game/GameManager.cs
+++ b/GOLF/Assets/_Project/Scripts/Game/GameManager.cs
@@ -7,7 +7,7 @@ namespace Golf
 {
     public class GameManager : Singleton<IGameSource>, IGameSource
     {
-        private const int INITIAL_STROKES = 50;
+        public const int INITIAL_STROKES = 50;
 
         [SerializeField] private int _strokesNumber;
 
@@ -15,8 +15,6 @@ namespace Golf
         public event Action OnLose;
         public event Action OnBallRespawn;
         public int CurrentHitsLeft => _strokesNumber;
-
-        public int InitialStrokes => INITIAL_STROKES;
 
         private readonly HashSet<string> _excludedScenes = new HashSet<string> { "Tutorial", "LevelSelector", "FireballCave" };
 
@@ -40,7 +38,7 @@ namespace Golf
 
         public void ResetHitsLeft()
         {
-            _strokesNumber = InitialStrokes;
+            _strokesNumber = INITIAL_STROKES;
         }
 
         public void TriggerLoseCondition()

--- a/GOLF/Assets/_Project/Scripts/Game/GameManager.cs
+++ b/GOLF/Assets/_Project/Scripts/Game/GameManager.cs
@@ -36,7 +36,7 @@ namespace Golf
 
         public void ResetHitsLeft()
         {
-            _strokesNumber = 5;
+            _strokesNumber = 50;
         }
 
         public void TriggerLoseCondition()

--- a/GOLF/Assets/_Project/Scripts/Game/GameManager.cs
+++ b/GOLF/Assets/_Project/Scripts/Game/GameManager.cs
@@ -7,12 +7,16 @@ namespace Golf
 {
     public class GameManager : Singleton<IGameSource>, IGameSource
     {
+        private const int INITIAL_STROKES = 50;
+
         [SerializeField] private int _strokesNumber;
 
         public event Action<int> OnHitsChanged;
         public event Action OnLose;
         public event Action OnBallRespawn;
         public int CurrentHitsLeft => _strokesNumber;
+
+        public int InitialStrokes => INITIAL_STROKES;
 
         private readonly HashSet<string> _excludedScenes = new HashSet<string> { "Tutorial", "LevelSelector", "FireballCave" };
 
@@ -36,7 +40,7 @@ namespace Golf
 
         public void ResetHitsLeft()
         {
-            _strokesNumber = 50;
+            _strokesNumber = InitialStrokes;
         }
 
         public void TriggerLoseCondition()

--- a/GOLF/Assets/_Project/Scripts/Game/IGameSource.cs
+++ b/GOLF/Assets/_Project/Scripts/Game/IGameSource.cs
@@ -9,6 +9,7 @@ namespace Golf
         event Action OnLose;
         event Action OnBallRespawn;
         int CurrentHitsLeft { get; }
+        int InitialStrokes { get; }
 
         void ReduceHitsLeft();
         void TriggerLoseCondition();

--- a/GOLF/Assets/_Project/Scripts/Game/IGameSource.cs
+++ b/GOLF/Assets/_Project/Scripts/Game/IGameSource.cs
@@ -9,7 +9,6 @@ namespace Golf
         event Action OnLose;
         event Action OnBallRespawn;
         int CurrentHitsLeft { get; }
-        int InitialStrokes { get; }
 
         void ReduceHitsLeft();
         void TriggerLoseCondition();

--- a/GOLF/Assets/_Project/Scripts/Save System/GameData.cs
+++ b/GOLF/Assets/_Project/Scripts/Save System/GameData.cs
@@ -7,7 +7,7 @@ namespace Golf
     {
         public int LastLevelCompleted = 0;
         public bool IsTutorialCleared = false;
-        public int StrokesNumber = 50;
+        public int StrokesNumber = GameManager.INITIAL_STROKES;
     }
 
     [Serializable]

--- a/GOLF/Assets/_Project/Scripts/Save System/GameData.cs
+++ b/GOLF/Assets/_Project/Scripts/Save System/GameData.cs
@@ -7,7 +7,7 @@ namespace Golf
     {
         public int LastLevelCompleted = 0;
         public bool IsTutorialCleared = false;
-        public int StrokesNumber = 20;
+        public int StrokesNumber = 50;
     }
 
     [Serializable]

--- a/GOLF/Assets/_Project/Scripts/Save System/SaveSystem.cs
+++ b/GOLF/Assets/_Project/Scripts/Save System/SaveSystem.cs
@@ -118,6 +118,7 @@ namespace Golf
             if (DoesFileExists(gameIndex))
             {
                 File.Delete(GetFilePath(gameIndex));
+                GameManager.Source.ResetHitsLeft();
             }
         }
 


### PR DESCRIPTION
There was an issue where the deleted slot's hits weren't being reset to the initial amount even after starting a new game and it would automatically show the Game Over panel. Here's a video showing a scene with 0 hits and after it gets deleted and start a new game, when you reach level 1 you have the original amount again.


https://github.com/user-attachments/assets/181a8da6-be26-4bb2-b695-d0e680cd8f5c

Close #227 