### PR TITLE
Fixed the HeavyShotCave and dialogues

### DIFF
--- a/GOLF/Assets/_Project/Art/Assets/Characters/gato_ajedrez.png.meta
+++ b/GOLF/Assets/_Project/Art/Assets/Characters/gato_ajedrez.png.meta
@@ -34,7 +34,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1
@@ -48,7 +48,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 16
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
@@ -82,6 +82,32 @@ TextureImporter:
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3
     buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1

--- a/GOLF/Assets/_Project/Scenes/HeavyShotCave.unity
+++ b/GOLF/Assets/_Project/Scenes/HeavyShotCave.unity
@@ -45401,7 +45401,7 @@ Transform:
   m_GameObject: {fileID: 2124575480}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 11.15, y: -6.8, z: 0}
+  m_LocalPosition: {x: 11.15, y: -6.99, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:

--- a/GOLF/Assets/_Project/Scenes/HeavyShotCave.unity
+++ b/GOLF/Assets/_Project/Scenes/HeavyShotCave.unity
@@ -3330,7 +3330,7 @@ CompositeCollider2D:
   m_GameObject: {fileID: 317566530}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 6200000, guid: d93588cfe59093c4d837d5f273e3638e, type: 2}
+  m_Material: {fileID: 6200000, guid: 5cbf2500f62bb14418a99d8fc591a768, type: 2}
   m_IncludeLayers:
     serializedVersion: 2
     m_Bits: 0
@@ -3359,9 +3359,21 @@ CompositeCollider2D:
   m_EdgeRadius: 0
   m_ColliderPaths:
   - m_Collider: {fileID: 317566534}
-    m_ColliderPaths: []
+    m_ColliderPaths:
+    - - X: 360000000
+        Y: -20000000
+      - X: 350000000
+        Y: -20000000
+      - X: 350000000
+        Y: -70000000
+      - X: 360000000
+        Y: -70000000
   m_CompositePaths:
-    m_Paths: []
+    m_Paths:
+    - - {x: 35.999973, y: -7}
+      - {x: 35.999973, y: -2}
+      - {x: 35, y: -2.0000293}
+      - {x: 35.00003, y: -7}
   m_VertexDistance: 0.0005
   m_OffsetDistance: 0.00005
   m_UseDelaunayMesh: 0
@@ -3486,7 +3498,57 @@ Tilemap:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 317566530}
   m_Enabled: 1
-  m_Tiles: {}
+  m_Tiles:
+  - first: {x: 35, y: -7, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 32
+      m_TileSpriteIndex: 32
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 35, y: -6, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 29
+      m_TileSpriteIndex: 29
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 35, y: -5, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 30
+      m_TileSpriteIndex: 30
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 35, y: -4, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 31
+      m_TileSpriteIndex: 31
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 35, y: -3, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 32
+      m_TileSpriteIndex: 32
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
   m_AnimatedTiles: {}
   m_TileAssetArray:
   - m_RefCount: 0
@@ -3547,14 +3609,14 @@ Tilemap:
     m_Data: {fileID: 0}
   - m_RefCount: 0
     m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 940f38bb42d1ac74dbe96bd9c452a063, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: a22be91bd8754634b9dd68f129f9cd74, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: c1b5565b6d9bc1d4ba84e807219adc0c, type: 2}
+  - m_RefCount: 2
+    m_Data: {fileID: 11400000, guid: f76bee4110a268a439da2864055f27a3, type: 2}
   m_TileSpriteArray:
   - m_RefCount: 0
     m_Data: {fileID: 0}
@@ -3614,36 +3676,36 @@ Tilemap:
     m_Data: {fileID: 0}
   - m_RefCount: 0
     m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
-  - m_RefCount: 0
-    m_Data: {fileID: 0}
+  - m_RefCount: 1
+    m_Data: {fileID: 1439272927, guid: 6a61584c0093a27499f46a105cf2864d, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -1014001757, guid: 6a61584c0093a27499f46a105cf2864d, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 785351317, guid: 6a61584c0093a27499f46a105cf2864d, type: 3}
+  - m_RefCount: 2
+    m_Data: {fileID: -1761270032, guid: 6a61584c0093a27499f46a105cf2864d, type: 3}
   m_TileMatrixArray:
-  - m_RefCount: 0
+  - m_RefCount: 5
     m_Data:
-      e00: 7.0684684e+28
+      e00: 1
       e01: 0
-      e02: -1.0288423e-38
-      e03: -1.0288423e-38
-      e10: 2.7900757e+20
-      e11: 0
-      e12: 8.58e-43
-      e13: 8.58e-43
-      e20: -2.1481819e+32
-      e21: 59.392456
-      e22: 5.523635e-19
-      e23: -1.620961e+29
-      e30: 4.5905e-41
-      e31: 8.62e-43
-      e32: 8.59e-43
-      e33: 8.6e-43
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
   m_TileColorArray:
-  - m_RefCount: 0
-    m_Data: {r: 5.2664e-41, g: 5.2664e-41, b: 5.2664e-41, a: 5.2664e-41}
+  - m_RefCount: 5
+    m_Data: {r: 1, g: 1, b: 1, a: 1}
   m_TileObjectToInstantiateArray: []
   m_AnimationFrameRate: 1
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -3857,6 +3919,90 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &374309569
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 374309570}
+  - component: {fileID: 374309571}
+  m_Layer: 0
+  m_Name: gato_ajedrez
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &374309570
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 374309569}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -29.8028, y: -5.3172, z: 0.26601744}
+  m_LocalScale: {x: 0.3752651, y: 0.3752651, z: 0.3752651}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2124575481}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &374309571
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 374309569}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: d98afb4865b32854eab0b03ac4e0f82a, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 3.5, y: 3.5}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &380401739
 GameObject:
   m_ObjectHideFlags: 0
@@ -4010,7 +4156,7 @@ BoxCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.46156287, y: 1.7597063}
+  m_Offset: {x: 1.6484542, y: 1.7597063}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -4021,7 +4167,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 5.211756, y: 4.5194125}
+  m_Size: {x: 2.8379736, y: 4.5194125}
   m_EdgeRadius: 0
 --- !u!1001 &419430222
 PrefabInstance:
@@ -33982,6 +34128,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 401716831}
+  - {fileID: 2124575481}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1905726425
@@ -45229,6 +45376,38 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2124575480
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2124575481}
+  m_Layer: 0
+  m_Name: El ajedrecista
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2124575481
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2124575480}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 11.15, y: -6.8, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 374309570}
+  m_Father: {fileID: 1791561268}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2131559130
 GameObject:
   m_ObjectHideFlags: 0

--- a/GOLF/Assets/_Project/ScriptableObjects/Dialogues/HeavyCave.asset
+++ b/GOLF/Assets/_Project/ScriptableObjects/Dialogues/HeavyCave.asset
@@ -16,17 +16,18 @@ MonoBehaviour:
   - Character: {fileID: 11400000, guid: 7025ae23c62cf1d4783b7307e18aa6d9, type: 2}
     Line: Hello! Are you another one of the... uh... cats who stayed here?
   - Character: {fileID: 11400000, guid: 0bed3636a8daf824ab971dc0fd932241, type: 2}
-    Line: Stay? Nah... I parked. Like a ball in the gutter.
+    Line: Mmm... technically, I'm in existential checkmate. But yes, you could say
+      I gave up before the end. A miscalculation.
   - Character: {fileID: 11400000, guid: 7025ae23c62cf1d4783b7307e18aa6d9, type: 2}
     Line: Oh... sorry. Did you play something before?
   - Character: {fileID: 11400000, guid: 0bed3636a8daf824ab971dc0fd932241, type: 2}
-    Line: Bowling. Thirty-nine strikes in a row. And then... a rat crossed the lane.
-      I lost the line. I lost the momentum. I lost...
+    Line: I played and breathed chess. Until a mouse distracted me in the middle
+      of a crucial game. I lost focus. I lost the queen.
   - Character: {fileID: 11400000, guid: 7025ae23c62cf1d4783b7307e18aa6d9, type: 2}
     Line: Wow! But you're still here. Have you thought about trying again?
   - Character: {fileID: 11400000, guid: 0bed3636a8daf824ab971dc0fd932241, type: 2}
     Line: Mmm... nah. Now I'm dedicated to philosophizing about the weight of things.
-      Life. The ball. Wet croquettes.
+      Life.
   - Character: {fileID: 11400000, guid: 7025ae23c62cf1d4783b7307e18aa6d9, type: 2}
     Line: Well, I'm right in the middle. I've already passed two camps... and although
       it's been difficult, I think I'm closer to returning to my human.

--- a/GOLF/Assets/_Project/ScriptableObjects/PowerUps/HeavyPowerUp.asset
+++ b/GOLF/Assets/_Project/ScriptableObjects/PowerUps/HeavyPowerUp.asset
@@ -12,7 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b112847a445174b48b80ba0241c4afc6, type: 3}
   m_Name: HeavyPowerUp
   m_EditorClassIdentifier: 
+  _powerUpType: 3
   _ballMass: 0.8
   _ballAngularDrag: 30
   _ballSprite: {fileID: 0}
   _hardness: 0
+  _hasEffect: 0


### PR DESCRIPTION
The chess-playing cat's dialogue needs to be changed (it used to be a bowling cat). There was a communication error, and I was told the dialogue was meant for a bowling cat.
The chess-playing cat has been added to the scene.
The walls that the power-up will be able to break have been added.
Close #240 

![image](https://github.com/user-attachments/assets/a2a2c645-2d08-43a0-8f8d-d018b9fa5da0)
